### PR TITLE
Fix: null gpt options

### DIFF
--- a/index.helper.ts
+++ b/index.helper.ts
@@ -84,13 +84,13 @@ export default class ChatGptLlmHelper
       ...{
         ...globalSettings,
         seed:
-          typeof options.seed === 'number' && options.seed >= 0
-            ? options.seed
+          typeof options?.seed === 'number' && options?.seed >= 0
+            ? options?.seed
             : null,
-        stop: !!options.stop ? options.stop : null,
+        stop: !!options?.stop ? options?.stop : null,
         top_logprobs:
-          typeof options.top_logprobs === 'number' && options.top_logprobs >= 0
-            ? options.top_logprobs
+          typeof options?.top_logprobs === 'number' && options?.top_logprobs >= 0
+            ? options?.top_logprobs
             : null,
         logit_bias: JSON.parse(globalSettings.logit_bias),
         max_completion_tokens: parseInt(


### PR DESCRIPTION
Fixes [#11](https://github.com/Hexastack/hexabot-helper-chatgpt/issues/11)

This PR updates the code to use optional chaining when accessing options.seed, ensuring it fails gracefully if options is null or undefined, and preventing runtime errors.